### PR TITLE
add mysql-shell engine as a supported engine

### DIFF
--- a/pkg/apis/planetscale/v2/vitesscluster_types.go
+++ b/pkg/apis/planetscale/v2/vitesscluster_types.go
@@ -316,7 +316,7 @@ type ClusterBackupSpec struct {
 	// from one tablet in each shard. Otherwise, new tablets trying to restore
 	// will find that the latest backup was created with the wrong engine.
 	// Default: builtin
-	// +kubebuilder:validation:Enum=builtin;xtrabackup
+	// +kubebuilder:validation:Enum=builtin;xtrabackup;mysqlshell
 	Engine VitessBackupEngine `json:"engine,omitempty"`
 	// Subcontroller specifies any parameters needed for launching the VitessBackupStorage subcontroller pod.
 	Subcontroller *VitessBackupSubcontrollerSpec `json:"subcontroller,omitempty"`
@@ -337,6 +337,8 @@ const (
 	VitessBackupEngineBuiltIn VitessBackupEngine = "builtin"
 	// VitessBackupEngineXtraBackup uses Percona XtraBackup for backups.
 	VitessBackupEngineXtraBackup VitessBackupEngine = "xtrabackup"
+	// VitessBackupEngineMySQLShell uses MySQL Shell for backups.
+	VitessBackupEngineMySQLShell VitessBackupEngine = "mysqlshell"
 )
 
 // LockserverSpec specifies either a deployed or external lockserver,


### PR DESCRIPTION
This change is dependant on https://github.com/vitessio/vitess/pull/16295#pullrequestreview-2188816148 as we are adding a new backup engine to Vitess. See the comment for additional context